### PR TITLE
Feature/86b6pzn9b enum criticalities

### DIFF
--- a/src/main/resources/db/migration/V6__add_enum_to_criticalities.sql
+++ b/src/main/resources/db/migration/V6__add_enum_to_criticalities.sql
@@ -1,0 +1,7 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'criticality_phase') THEN
+        CREATE TYPE criticality_phase AS ENUM ('antes', 'durante', 'depois');
+    END IF;
+END
+$$;

--- a/src/main/resources/db/migration/V6__add_enum_to_criticalities.sql
+++ b/src/main/resources/db/migration/V6__add_enum_to_criticalities.sql
@@ -1,7 +1,1 @@
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'criticality_phase') THEN
-        CREATE TYPE criticality_phase AS ENUM ('antes', 'durante', 'depois');
-    END IF;
-END
-$$;
+CREATE TYPE criticality_phase AS ENUM ('antes', 'durante', 'depois');


### PR DESCRIPTION
Adicionar tipo ENUM para as criticalidades(antes, durante e depois)

Não permite duplicatas

Pode ser usado por qualquer tabela que precise dessas informações.